### PR TITLE
Chore: remove temp styles in favour of embedded discourse styles

### DIFF
--- a/src/css/stylesheet.css
+++ b/src/css/stylesheet.css
@@ -178,8 +178,3 @@ article .kg-gallery-image {
 .discourse-comments {
   @apply mt-10;
 }
-
-.discourse-comments iframe {
-  @apply p-6;
-  background-color: #ffffff;
-}


### PR DESCRIPTION
# Description

I'm currently styling the embedded discourse comments(live 🙈) from within discourse, so i'll merge this once i'm ready to save those changes. This was just a temporary fix to make the comments look a little better since the embedded styles weren't working before

## Link to issue

https://github.com/fission-codes/landing-page/issues/76

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## Screenshots/Screencaps

TBD