### PR TITLE
Update luma link in footer

### DIFF
--- a/src/_includes/partials/footer.njk
+++ b/src/_includes/partials/footer.njk
@@ -46,7 +46,7 @@
                         Check Out Our Open Roles
                     </a>
                     <a aria-label="View the Fission Events page"
-                        href="https://lu.ma/fission-online-events"
+                        href="https://lu.ma/fissionevents"
                         target="_blank"
                         class="btn btn-outline font-normal items-center gap-2 w-full text-newneutral-0 rounded-lg border-newneutral-0 border">
                         View Our Events Calendar


### PR DESCRIPTION
updated luma link

# Description

With the consolidation of Fission Luma accounts under one url, this link had gone un-updated.

## Link to issue

- no issue

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue)
